### PR TITLE
[SELS-TASK] User Authentication - Implement Loading States

### DIFF
--- a/frontend/src/actions/types.ts
+++ b/frontend/src/actions/types.ts
@@ -1,9 +1,20 @@
-export enum ActionTypes {
-  registerUser,
-  loginUser,
-  logoutUser,
+export enum registerTypes {
+  registerUserRequest,
+  registerUserSuccess,
+  registerUserError,
 }
 
+export enum loginTypes {
+  loginUserRequest,
+  loginUserSuccess,
+  loginUserError,
+}
+
+export enum logoutTypes {
+  logoutUserRequest,
+  logoutUserSuccess,
+  logoutUserError,
+}
 export interface RegistrationData {
   email: string;
   name: string;
@@ -11,8 +22,8 @@ export interface RegistrationData {
   password_confirmation: string;
 }
 export interface RegisterUserAction {
-  type: ActionTypes.registerUser;
-  payload: AuthenticationPayloadData;
+  type: registerTypes;
+  payload?: AuthenticationPayloadData;
 }
 
 export interface LoginData {
@@ -21,8 +32,8 @@ export interface LoginData {
 }
 
 export interface LoginUserAction {
-  type: ActionTypes.loginUser;
-  payload: AuthenticationPayloadData;
+  type: loginTypes;
+  payload?: AuthenticationPayloadData;
 }
 
 export interface UserToken {
@@ -54,11 +65,11 @@ export interface LogoutData {
 }
 
 export interface LogoutUserAction {
-  type: ActionTypes.logoutUser;
-  payload: LogoutData;
+  type: logoutTypes;
+  payload?: LogoutData;
 }
 
 export interface UserTokenActions {
-  type: ActionTypes;
+  type: registerTypes | loginTypes | logoutTypes;
   payload: LoginData | RegistrationData | LogoutData;
 }

--- a/frontend/src/actions/user.ts
+++ b/frontend/src/actions/user.ts
@@ -1,8 +1,12 @@
 import axios from 'axios';
 import { Dispatch } from 'redux';
-import { LogoutData, LogoutUserAction } from './types';
 import {
-  ActionTypes,
+  LogoutData,
+  LogoutUserAction,
+  registerTypes,
+  loginTypes,
+} from './types';
+import {
   LoginData,
   LoginUserAction,
   RegisterUserAction,
@@ -10,9 +14,13 @@ import {
 } from './types';
 
 import { config } from './config';
+import { logoutTypes } from './types';
 
 export const registerUser = (registration_data: RegistrationData) => {
   return async (dispatch: Dispatch) => {
+    dispatch<RegisterUserAction>({
+      type: registerTypes.registerUserRequest,
+    });
     await axios
       .post<RegistrationData, any, RegistrationData>(
         `${config.URL}/register`,
@@ -20,34 +28,37 @@ export const registerUser = (registration_data: RegistrationData) => {
       )
       .then((res) => {
         dispatch<RegisterUserAction>({
-          type: ActionTypes.registerUser,
+          type: registerTypes.registerUserSuccess,
           payload: res.data,
         });
-
         localStorage.setItem('SessionData', JSON.stringify(res.data));
-        alert('Success!');
       });
   };
 };
 
 export const loginUser = (login_data: LoginData) => {
   return async (dispatch: Dispatch) => {
+    dispatch<LoginUserAction>({
+      type: loginTypes.loginUserRequest,
+    });
     await axios
       .post<LoginData, any, LoginData>(`${config.URL}/login`, login_data)
       .then((res) => {
         dispatch<LoginUserAction>({
-          type: ActionTypes.loginUser,
+          type: loginTypes.loginUserSuccess,
           payload: res.data,
         });
 
         localStorage.setItem('SessionData', JSON.stringify(res.data));
-        alert('Success!');
       });
   };
 };
 
 export const logoutUser = ({ user_id, token }: LogoutData) => {
   return async (dispatch: Dispatch) => {
+    dispatch<LogoutUserAction>({
+      type: logoutTypes.logoutUserRequest,
+    });
     await axios
       .post(
         `${config.URL}/logout`,
@@ -56,7 +67,7 @@ export const logoutUser = ({ user_id, token }: LogoutData) => {
       )
       .then((res) => {
         dispatch<LogoutUserAction>({
-          type: ActionTypes.logoutUser,
+          type: logoutTypes.logoutUserSuccess,
           payload: res.data,
         });
 

--- a/frontend/src/layout/Navbar.tsx
+++ b/frontend/src/layout/Navbar.tsx
@@ -34,10 +34,10 @@ class _Navbar extends Component<Props> {
               onClick={this.logoutSession}
             >
               {this.props.loading ? (
-                <div className='flex items-center justify-center'>
-                  <div className='w-4 h-4 border-b-2 border-white-900 rounded-full animate-spin mr-5'></div>
+                <span className='flex items-center justify-center'>
+                  <span className='w-4 h-4 border-b-2 border-white-900 rounded-full animate-spin mr-5'></span>
                   Logout
-                </div>
+                </span>
               ) : (
                 'Logout'
               )}
@@ -57,7 +57,7 @@ class _Navbar extends Component<Props> {
     );
   }
 
-  getLoginState() {
+  render() {
     return (
       <div>
         <div className='navbar mb-2 shadow-lg bg-neutral text-neutral-content rounded-box'>

--- a/frontend/src/layout/Navbar.tsx
+++ b/frontend/src/layout/Navbar.tsx
@@ -5,16 +5,17 @@ import { User } from '../actions/types';
 import { logoutUser } from '../actions/user';
 import { Link } from 'react-router-dom';
 interface Props {
-  SessionData?: {
-    user: User;
-    token: string;
+  SessionData: {
+    user?: User;
+    token?: string;
   };
   logoutUser: Function;
+  loading: boolean;
 }
 
 class _Navbar extends Component<Props> {
   logoutSession = (): void => {
-    if (this.props.SessionData) {
+    if (this.props.SessionData.user) {
       this.props.logoutUser({
         user_id: this.props.SessionData.user.id,
         token: this.props.SessionData.token,
@@ -25,14 +26,21 @@ class _Navbar extends Component<Props> {
   getLoginState() {
     return (
       <div className='mr-2'>
-        {this.props.SessionData ? (
+        {this.props.SessionData.user ? (
           <div>
             <span className='text-lg font-bold mr-4'>{`Hello, ${this.props.SessionData.user.name}!`}</span>
             <button
               className='btn btn-sm btn-info mr-5'
               onClick={this.logoutSession}
             >
-              Logout
+              {this.props.loading ? (
+                <div className='flex items-center justify-center'>
+                  <div className='w-4 h-4 border-b-2 border-white-900 rounded-full animate-spin mr-5'></div>
+                  Logout
+                </div>
+              ) : (
+                'Logout'
+              )}
             </button>
           </div>
         ) : (
@@ -49,7 +57,7 @@ class _Navbar extends Component<Props> {
     );
   }
 
-  render() {
+  getLoginState() {
     return (
       <div>
         <div className='navbar mb-2 shadow-lg bg-neutral text-neutral-content rounded-box'>
@@ -68,6 +76,7 @@ class _Navbar extends Component<Props> {
 const mapStateToProps = (state: any) => {
   return {
     SessionData: state.userToken.SessionData,
+    loading: state.logout.loading,
   };
 };
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,11 +1,15 @@
 import React from 'react';
-import { useDispatch } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { LoginData } from '../actions/types';
 import { loginUser } from '../actions/user';
 import { useForm } from 'react-hook-form';
 import FormError from '../components/FormError';
 
-function LoginPage() {
+interface Props {
+  loading: boolean;
+}
+
+function LoginPage(props: Props) {
   const loginDataValidation = {
     email: {
       required: {
@@ -57,15 +61,26 @@ function LoginPage() {
             {...register('password', loginDataValidation.password)}
           />
           <FormError message={errors.password?.message} />
-          <input
-            className='btn btn-info mt-5 w-1/2 mx-auto'
-            type='submit'
-            value='Login'
-          />
+          <button className='btn btn-info mt-5 w-1/2 mx-auto' type='submit'>
+            {props.loading ? (
+              <div className='flex items-center justify-center'>
+                <div className='w-4 h-4 border-b-2 border-white-900 rounded-full animate-spin mr-5'></div>
+                Login
+              </div>
+            ) : (
+              'Login'
+            )}
+          </button>
         </form>
       </div>
     </div>
   );
 }
 
-export default LoginPage;
+const mapStateToProps = (state: any) => {
+  return {
+    loading: state.login.loading,
+  };
+};
+
+export default connect(mapStateToProps)(LoginPage);

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -63,10 +63,10 @@ function LoginPage(props: Props) {
           <FormError message={errors.password?.message} />
           <button className='btn btn-info mt-5 w-1/2 mx-auto' type='submit'>
             {props.loading ? (
-              <div className='flex items-center justify-center'>
-                <div className='w-4 h-4 border-b-2 border-white-900 rounded-full animate-spin mr-5'></div>
+              <span className='flex items-center justify-center'>
+                <span className='w-4 h-4 border-b-2 border-white-900 rounded-full animate-spin mr-5'></span>
                 Login
-              </div>
+              </span>
             ) : (
               'Login'
             )}

--- a/frontend/src/pages/RegistrationPage.tsx
+++ b/frontend/src/pages/RegistrationPage.tsx
@@ -1,11 +1,15 @@
 import React, { useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { registerUser } from '../actions/user';
-import { RegistrationData } from '../actions';
-import { useDispatch } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import FormError from '../components/FormError';
+import { RegistrationData } from '../actions/types';
 
-export default function RegistrationPage() {
+interface Props {
+  loading: boolean;
+}
+
+function RegistrationPage(props: Props) {
   // This has to be inside to access password.current for validation
   const registrationDataValidation = {
     email: {
@@ -93,13 +97,26 @@ export default function RegistrationPage() {
             )}
           />
           <FormError message={errors.password_confirmation?.message} />
-          <input
-            className='btn btn-info mt-5 w-1/2 mx-auto'
-            type='submit'
-            value='Register'
-          />
+          <button className='btn btn-info mt-5 w-1/2 mx-auto' type='submit'>
+            {props.loading ? (
+              <div className='flex items-center justify-center'>
+                <div className='w-4 h-4 border-b-2 border-white-900 rounded-full animate-spin mr-5'></div>
+                Register
+              </div>
+            ) : (
+              'Register'
+            )}
+          </button>
         </form>
       </div>
     </div>
   );
 }
+
+const mapStateToProps = (state: any) => {
+  return {
+    loading: state.register.loading,
+  };
+};
+
+export default connect(mapStateToProps)(RegistrationPage);

--- a/frontend/src/pages/RegistrationPage.tsx
+++ b/frontend/src/pages/RegistrationPage.tsx
@@ -99,10 +99,10 @@ function RegistrationPage(props: Props) {
           <FormError message={errors.password_confirmation?.message} />
           <button className='btn btn-info mt-5 w-1/2 mx-auto' type='submit'>
             {props.loading ? (
-              <div className='flex items-center justify-center'>
-                <div className='w-4 h-4 border-b-2 border-white-900 rounded-full animate-spin mr-5'></div>
+              <span className='flex items-center justify-center'>
+                <span className='w-4 h-4 border-b-2 border-white-900 rounded-full animate-spin mr-5'></span>
                 Register
-              </div>
+              </span>
             ) : (
               'Register'
             )}

--- a/frontend/src/reducers/user.ts
+++ b/frontend/src/reducers/user.ts
@@ -1,7 +1,7 @@
+import { registerTypes, loginTypes, logoutTypes } from '../actions/types';
 import {
   RegisterUserAction,
   LoginUserAction,
-  ActionTypes,
   UserTokenActions,
   LogoutUserAction,
   AuthenticationPayloadData,
@@ -9,8 +9,16 @@ import {
 
 export const registerUserReducer = (state = {}, action: RegisterUserAction) => {
   switch (action.type) {
-    case ActionTypes.registerUser:
-      return action.payload;
+    case registerTypes.registerUserRequest:
+      return {
+        ...state,
+        loading: true,
+      };
+    case registerTypes.registerUserSuccess:
+      return {
+        ...state,
+        loading: false,
+      };
     default:
       return state;
   }
@@ -18,8 +26,16 @@ export const registerUserReducer = (state = {}, action: RegisterUserAction) => {
 
 export const loginUserReducer = (state = {}, action: LoginUserAction) => {
   switch (action.type) {
-    case ActionTypes.loginUser:
-      return action.payload;
+    case loginTypes.loginUserRequest:
+      return {
+        ...state,
+        loading: true,
+      };
+    case loginTypes.loginUserSuccess:
+      return {
+        ...state,
+        loading: false,
+      };
     default:
       return state;
   }
@@ -27,8 +43,16 @@ export const loginUserReducer = (state = {}, action: LoginUserAction) => {
 
 export const logoutUserReducer = (state = {}, action: LogoutUserAction) => {
   switch (action.type) {
-    case ActionTypes.logoutUser:
-      return action.payload;
+    case logoutTypes.logoutUserRequest:
+      return {
+        ...state,
+        loading: true,
+      };
+    case logoutTypes.logoutUserSuccess:
+      return {
+        ...state,
+        loading: false,
+      };
     default:
       return state;
   }
@@ -45,11 +69,11 @@ export const userTokenReducer = (
   action: UserTokenActions
 ) => {
   switch (action.type) {
-    case ActionTypes.loginUser:
+    case loginTypes.loginUserSuccess:
       return { ...state, SessionData: action.payload };
-    case ActionTypes.logoutUser:
+    case logoutTypes.logoutUserSuccess:
       return { ...state, SessionData: null };
-    case ActionTypes.registerUser:
+    case registerTypes.registerUserSuccess:
       return { ...state, SessionData: action.payload };
     default:
       return state;


### PR DESCRIPTION
[Asana Link]
[Task](https://app.asana.com/0/1201478050789804/1201517878886175/f)

[Commands]
`cd backend/ && php artisan serve`
`cd frontend/ && npm start`

[Pre-conditions]
- .env is setup with a database

[Expected Output]
- Authentication actions should show loading states
    - includes Registration, Login, and Logout

[Notes]
I have realized in a future branch that doing this does not work
```
export enum registerTypes {
  registerUserRequest,
  registerUserSuccess,
  registerUserError,
}

export enum loginTypes {
  loginUserRequest,
  loginUserSuccess,
  loginUserError,
}
...
```
This is changed into a singular Types enum in [PR #17](https://github.com/framgia/sph_els_ervin/blob/1b72a4af52b414ad4bd9b774e8d594aeb2ca489a/frontend/src/actions/types.ts)

[Screenshots]